### PR TITLE
fix/mineral_purchase_0

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -927,6 +927,12 @@
       "mineralId": 4,
       "quantity": 1,
       "id": 63
+    },
+    {
+      "colonyId": 5,
+      "mineralId": 13,
+      "quantity": 1,
+      "id": 64
     }
   ]
 }

--- a/scripts/MiningFacilities.js
+++ b/scripts/MiningFacilities.js
@@ -1,4 +1,4 @@
-import { setFacilityId, state } from "./TransientState.js";
+import { setFacilityId, setSelectedMineralId, state } from "./TransientState.js";
 import { getAllMiningFacilities } from "./managers/miningFacilityManager.js";
 
 
@@ -27,6 +27,7 @@ export const facilities = async () => {
   const facilitiesChangeHandler = (e) => {
     if (e.target.id === "facilities") {
       setFacilityId(parseInt(e.target.value));
+      setSelectedMineralId(0)
   }
 };
 


### PR DESCRIPTION

# Description

fix a bug caused by the transient state holdover from minerals when facility changed

Fixes # (issue)

An error would occur if a mineral is selected the transient state would retain the value even if the facility changed and no longer had the selected mineral causing the database to increment the proper object, but having no valid target to decrement.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1 fetch the branch in title
- [ ] Step 2 switch to the target branch and refresh your browser
- [ ] Step 3 select a governor, facility, a mineral, and then switch to a facility that doesn't have your mineral and then purchase

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors
